### PR TITLE
Add tSkipShortExternal to the new network tests

### DIFF
--- a/htmltest/htmltest_test.go
+++ b/htmltest/htmltest_test.go
@@ -128,6 +128,7 @@ func TestConcurrencyDirExternals(t *testing.T) {
 }
 
 func TestRedirectLimitDefault(t *testing.T) {
+	tSkipShortExternal(t)
 	hT := tTestFileOpts("fixtures/links/http_no_redirect.html",
 		map[string]interface{}{"RedirectLimit": -2})
 	tExpectIssueCount(t, hT, 0)
@@ -137,6 +138,7 @@ func TestRedirectLimitDefault(t *testing.T) {
 }
 
 func TestRedirectLimitOk(t *testing.T) {
+	tSkipShortExternal(t)
 	hT := tTestFileOpts("fixtures/links/http_no_redirect.html",
 		map[string]interface{}{"RedirectLimit": 0})
 	tExpectIssueCount(t, hT, 0)
@@ -146,6 +148,7 @@ func TestRedirectLimitOk(t *testing.T) {
 }
 
 func TestRedirectLimitExceeded(t *testing.T) {
+	tSkipShortExternal(t)
 	hT := tTestFileOpts("fixtures/links/http_one_redirect.html",
 		map[string]interface{}{"RedirectLimit": 0})
 	tExpectIssueCount(t, hT, 1)


### PR DESCRIPTION
In https://github.com/wjdp/htmltest/commit/d785ba51dd8b6a10ea60696ec4cb9d34f80c1b39, new tests were added that rely on network.

We're adding the tSkipShortExternal option to bypass them in -short mode.